### PR TITLE
fix: release background input and updater fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,17 @@ on:
   push:
     branches:
       - main
+      - bate
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Release channel"
+        required: true
+        default: "stable"
+        type: choice
+        options:
+          - stable
+          - beta
       bump:
         description: "Version bump to release"
         required: true
@@ -36,6 +45,7 @@ jobs:
       should_release: ${{ steps.version.outputs.should_release }}
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      channel: ${{ steps.version.outputs.channel }}
       release_notes: ${{ steps.version.outputs.release_notes }}
 
     steps:
@@ -46,14 +56,29 @@ jobs:
       - name: Compute next version
         id: version
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REQUESTED_CHANNEL: ${{ inputs.channel || '' }}
+          REQUESTED_BUMP: ${{ inputs.bump || '' }}
         run: |
           set -euo pipefail
 
           subject="$(git log -1 --pretty=%s)"
+          channel="${REQUESTED_CHANNEL:-}"
+          if [[ -z "$channel" ]]; then
+            if [[ "$REF_NAME" == "bate" ]]; then
+              channel="beta"
+            else
+              channel="stable"
+            fi
+          fi
+
           bump=""
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            bump="${{ inputs.bump }}"
+          if [[ "$channel" == "beta" ]]; then
+            bump="patch"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            bump="$REQUESTED_BUMP"
           elif [[ "$subject" =~ ^feat(\(.+\))?!?: ]]; then
             bump="minor"
           elif [[ "$subject" =~ ^fix(\(.+\))?: ]]; then
@@ -66,7 +91,10 @@ jobs:
             exit 0
           fi
 
-          latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)"
+          latest_tag="$(git tag --list 'v*' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -Vr \
+            | head -n 1 || true)"
 
           if [[ -z "$latest_tag" ]]; then
             version="0.1.0"
@@ -96,6 +124,19 @@ jobs:
             version="$major.$minor.$patch"
           fi
 
+          if [[ "$channel" == "beta" ]]; then
+            raw="${latest_tag#v}"
+            if [[ -z "$latest_tag" ]]; then
+              major=0
+              minor=1
+              patch=0
+            else
+              IFS='.' read -r major minor patch <<< "$raw"
+              patch=$((patch + 1))
+            fi
+            version="$major.$minor.$patch-beta.${GITHUB_RUN_NUMBER}"
+          fi
+
           tag="v$version"
 
           if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
@@ -106,6 +147,7 @@ jobs:
           echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
 
           # Release notes should read like product notes, not a commit/CI dump.
           # Prefer the curated "## [Unreleased]" section of CHANGELOG.md; fall
@@ -269,15 +311,28 @@ jobs:
         shell: bash
         env:
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           node - <<'NODE'
           const fs = require('fs');
           const version = process.env.RELEASE_VERSION;
+          const channel = process.env.RELEASE_CHANNEL;
           for (const file of ['package.json', 'src-tauri/tauri.conf.json']) {
             const data = JSON.parse(fs.readFileSync(file, 'utf8'));
             data.version = version;
+            if (file === 'src-tauri/tauri.conf.json' && channel === 'beta') {
+              data.plugins.updater.endpoints = [
+                'https://github.com/XxMinor/mykvm/releases/download/beta/latest.json',
+              ];
+            }
             fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
           }
+
+          const cargoToml = fs.readFileSync('src-tauri/Cargo.toml', 'utf8');
+          fs.writeFileSync(
+            'src-tauri/Cargo.toml',
+            cargoToml.replace(/^version = ".*"$/m, `version = "${version}"`),
+          );
           NODE
 
       - name: Validate Apple signing secrets
@@ -437,7 +492,7 @@ jobs:
           # updater (releases/latest/download/latest.json) 404s for the rest of
           # the build. A failed build also never becomes "latest" this way.
           releaseDraft: true
-          prerelease: false
+          prerelease: ${{ needs.prepare.outputs.channel == 'beta' }}
           # latest.json is assembled by the dedicated assemble-latest-json job
           # (single source of truth across platforms); the .sig artifacts are
           # uploaded by tauri-action regardless.
@@ -511,6 +566,7 @@ jobs:
           REPO: ${{ github.repository }}
           TAG: ${{ needs.prepare.outputs.tag }}
           VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_NOTES: ${{ needs.prepare.outputs.release_notes }}
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -518,9 +574,10 @@ jobs:
           const path = require('path');
 
           const dir = 'dl';
-          const files = fs.readdirSync(dir);
+          let files = fs.readdirSync(dir);
           const tag = process.env.TAG;
           const version = process.env.VERSION;
+          const notes = process.env.RELEASE_NOTES || `Release ${tag}`;
           const baseUrl = `https://github.com/${process.env.REPO}/releases/download/${tag}`;
           const assetUrl = (name) => `${baseUrl}/${encodeURIComponent(name)}`;
           const signatureFor = (name) => {
@@ -559,10 +616,18 @@ jobs:
           const windowsAsset = files.find(
             (name) =>
               !name.endsWith('.sig') &&
+              name !== 'mykvm-windows-x64-setup.exe' &&
               (/setup\.exe$/i.test(name) || /\.msi$/i.test(name)),
           );
           if (windowsAsset) {
-            addPlatform('windows-x86_64', windowsAsset);
+            const windowsUpdaterAsset = 'mykvm-windows-x64-setup.exe';
+            fs.copyFileSync(path.join(dir, windowsAsset), path.join(dir, windowsUpdaterAsset));
+            fs.copyFileSync(
+              path.join(dir, `${windowsAsset}.sig`),
+              path.join(dir, `${windowsUpdaterAsset}.sig`),
+            );
+            files = fs.readdirSync(dir);
+            addPlatform('windows-x86_64', windowsUpdaterAsset);
           }
 
           const linuxAsset = files.find(
@@ -580,7 +645,7 @@ jobs:
             `${JSON.stringify(
               {
                 version,
-                notes: `Release ${tag}`,
+                notes,
                 pub_date: new Date().toISOString(),
                 platforms,
               },
@@ -596,17 +661,43 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           set -euo pipefail
+          if [[ -f dl/mykvm-windows-x64-setup.exe ]]; then
+            gh release upload "$TAG" \
+              dl/mykvm-windows-x64-setup.exe \
+              dl/mykvm-windows-x64-setup.exe.sig \
+              --clobber \
+              --repo "$GITHUB_REPOSITORY"
+          fi
           gh release upload "$TAG" latest.json --clobber --repo "$GITHUB_REPOSITORY"
+          if [[ "$CHANNEL" == "beta" ]]; then
+            if gh release view beta --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              gh release upload beta latest.json --clobber --repo "$GITHUB_REPOSITORY"
+            else
+              gh release create beta latest.json \
+                --target "$GITHUB_SHA" \
+                --title "MyKVM Beta Updates" \
+                --notes "Updater manifest for beta builds." \
+                --prerelease \
+                --latest=false \
+                --repo "$GITHUB_REPOSITORY"
+            fi
+          fi
 
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           set -euo pipefail
           # Now that every platform bundle AND latest.json are attached, flip the
           # draft to published. Only at this point does releases/latest advance to
           # this tag, so the in-app updater never sees a manifest-less release.
-          gh release edit "$TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"
+          if [[ "$CHANNEL" == "beta" ]]; then
+            gh release edit "$TAG" --draft=false --prerelease --latest=false --repo "$GITHUB_REPOSITORY"
+          else
+            gh release edit "$TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"
+          fi

--- a/src-tauri/src/input.rs
+++ b/src-tauri/src/input.rs
@@ -97,9 +97,7 @@ const MACOS_RAW_GESTURE_EVENT_TYPES: &[u32] = &[
     MACOS_NSEVENT_TYPE_CHANGE_MODE,
 ];
 #[cfg(target_os = "windows")]
-const WINDOWS_FULLSCREEN_EDGE_TOLERANCE: i32 = 3;
-#[cfg(target_os = "windows")]
-const WINDOWS_FULLSCREEN_CHECK_INTERVAL_MS: u64 = 250;
+const WINDOWS_DESKTOP_CHECK_INTERVAL_MS: u64 = 250;
 
 static REMOTE_MOUSE_STATE: OnceLock<Mutex<RemoteMouseState>> = OnceLock::new();
 #[cfg(target_os = "macos")]
@@ -966,7 +964,6 @@ fn start_platform_capture(
             remote_button_mask: AtomicU64::new(0),
             pressed_keys: Mutex::new(Vec::new()),
             cursor_hide_calls: Mutex::new(0),
-            fullscreen_foreground_cache: Mutex::new(None),
             just_crossed: AtomicBool::new(false),
             local_screen_points: Mutex::new(HashMap::new()),
         });
@@ -1079,7 +1076,7 @@ fn start_platform_receive_monitor(stop: Arc<AtomicBool>) {
         refresh_windows_input_desktop_cache();
         while !stop.load(Ordering::Relaxed) {
             refresh_windows_input_desktop_cache();
-            thread::sleep(Duration::from_millis(WINDOWS_FULLSCREEN_CHECK_INTERVAL_MS));
+            thread::sleep(Duration::from_millis(WINDOWS_DESKTOP_CHECK_INTERVAL_MS));
         }
     });
 }
@@ -2351,7 +2348,6 @@ struct WindowsCaptureContext {
     remote_button_mask: AtomicU64,
     pressed_keys: Mutex<Vec<u16>>,
     cursor_hide_calls: Mutex<u8>,
-    fullscreen_foreground_cache: Mutex<Option<(Instant, bool)>>,
     // Swallow the first post-crossing delta so a fast flick across the edge
     // does not shove the cursor inward on Windows, where we pin by warping.
     just_crossed: AtomicBool,
@@ -2607,9 +2603,6 @@ unsafe extern "system" fn windows_mouse_proc(code: i32, wparam: usize, lparam: i
         release_windows_remote_control(&context, true);
         return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
     }
-    if should_suspend_windows_capture(&context) {
-        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
-    }
 
     let event = unsafe { *(lparam as *const MSLLHOOKSTRUCT) };
     let message = wparam as u32;
@@ -2647,10 +2640,6 @@ unsafe extern "system" fn windows_keyboard_proc(code: i32, wparam: usize, lparam
     }
 
     let message = wparam as u32;
-
-    if should_suspend_windows_capture(&context) {
-        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
-    }
 
     let active = context
         .active
@@ -2797,36 +2786,6 @@ fn release_windows_remote_control(context: &WindowsCaptureContext, clear_clipboa
 }
 
 #[cfg(target_os = "windows")]
-fn should_suspend_windows_capture(context: &WindowsCaptureContext) -> bool {
-    if windows_foreground_window_is_fullscreen_cached(context) {
-        release_windows_remote_control(context, true);
-        return true;
-    }
-
-    false
-}
-
-#[cfg(target_os = "windows")]
-fn windows_foreground_window_is_fullscreen_cached(context: &WindowsCaptureContext) -> bool {
-    let now = Instant::now();
-    if let Ok(mut cache) = context.fullscreen_foreground_cache.lock() {
-        if let Some((checked_at, value)) = *cache {
-            if now.duration_since(checked_at)
-                < Duration::from_millis(WINDOWS_FULLSCREEN_CHECK_INTERVAL_MS)
-            {
-                return value;
-            }
-        }
-
-        let value = windows_foreground_window_is_fullscreen();
-        *cache = Some((now, value));
-        return value;
-    }
-
-    windows_foreground_window_is_fullscreen()
-}
-
-#[cfg(target_os = "windows")]
 fn cached_windows_input_desktop_is_default() -> bool {
     WINDOWS_INPUT_DESKTOP_DEFAULT_CACHE.load(Ordering::Relaxed)
 }
@@ -2873,84 +2832,6 @@ fn windows_input_desktop_is_default() -> bool {
 
         name.eq_ignore_ascii_case("default")
     }
-}
-
-#[cfg(target_os = "windows")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct WindowsRect {
-    left: i32,
-    top: i32,
-    right: i32,
-    bottom: i32,
-}
-
-#[cfg(target_os = "windows")]
-fn windows_foreground_window_is_fullscreen() -> bool {
-    use windows_sys::Win32::{
-        Foundation::RECT,
-        Graphics::Gdi::{
-            GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
-        },
-        System::Threading::GetCurrentProcessId,
-        UI::WindowsAndMessaging::{
-            GetForegroundWindow, GetWindowRect, GetWindowThreadProcessId, IsWindowVisible,
-        },
-    };
-
-    unsafe {
-        let hwnd = GetForegroundWindow();
-        if hwnd.is_null() || IsWindowVisible(hwnd) == 0 {
-            return false;
-        }
-
-        let mut foreground_pid = 0_u32;
-        GetWindowThreadProcessId(hwnd, &mut foreground_pid);
-        if foreground_pid == GetCurrentProcessId() {
-            return false;
-        }
-
-        let mut window_rect = RECT::default();
-        if GetWindowRect(hwnd, &mut window_rect) == 0 {
-            return false;
-        }
-
-        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-        if monitor.is_null() {
-            return false;
-        }
-        let mut monitor_info = MONITORINFO {
-            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
-            rcMonitor: RECT::default(),
-            rcWork: RECT::default(),
-            dwFlags: 0,
-        };
-        if GetMonitorInfoW(monitor, &mut monitor_info) == 0 {
-            return false;
-        }
-
-        rect_covers_monitor(
-            WindowsRect {
-                left: window_rect.left,
-                top: window_rect.top,
-                right: window_rect.right,
-                bottom: window_rect.bottom,
-            },
-            WindowsRect {
-                left: monitor_info.rcMonitor.left,
-                top: monitor_info.rcMonitor.top,
-                right: monitor_info.rcMonitor.right,
-                bottom: monitor_info.rcMonitor.bottom,
-            },
-        )
-    }
-}
-
-#[cfg(target_os = "windows")]
-fn rect_covers_monitor(window: WindowsRect, monitor: WindowsRect) -> bool {
-    window.left <= monitor.left + WINDOWS_FULLSCREEN_EDGE_TOLERANCE
-        && window.top <= monitor.top + WINDOWS_FULLSCREEN_EDGE_TOLERANCE
-        && window.right >= monitor.right - WINDOWS_FULLSCREEN_EDGE_TOLERANCE
-        && window.bottom >= monitor.bottom - WINDOWS_FULLSCREEN_EDGE_TOLERANCE
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1417,7 +1417,9 @@ fn restart_runtime_if_running(state: &AppRuntime) -> Result<(), String> {
 
     state.stop_input();
     state.stop_clipboard();
-    state.stop_discovery();
+    // Keep discovery/QUIC alive across input/clipboard restarts. Rebuilding the
+    // QUIC endpoint on the same UDP port can briefly race the old endpoint and
+    // make peers see "server refused to accept a new connection".
     thread::sleep(Duration::from_millis(300));
     state.start_discovery()?;
     let layout = state.layout_snapshot();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8426,6 +8426,46 @@ mod tests {
     }
 
     #[test]
+    fn clipboard_formats_packet_preserves_non_ascii_text() {
+        let layout = test_layout();
+        let packet = clipboard_packet_from_content(
+            ClipboardContent::Text("中文测试 abc 123".into()),
+            "peer-client-10-0-0-2".into(),
+            "local-device".into(),
+            layout.cluster_id.clone(),
+            layout.pair_secret.clone(),
+            1,
+        );
+        let payload = encode_wire_packet(&packet).expect("clipboard packet should encode");
+        let clipboard_seen_text = Arc::new(Mutex::new(None));
+        let clipboard_echo_until = Arc::new(Mutex::new(None));
+        let clipboard_last_sequences = Arc::new(Mutex::new(HashMap::new()));
+        let mut written = None;
+
+        let accepted = handle_clipboard_packet_with_writer(
+            &payload,
+            &layout,
+            "local-device",
+            &clipboard_seen_text,
+            &clipboard_echo_until,
+            &clipboard_last_sequences,
+            |content| {
+                if let ClipboardContent::Text(text) = content {
+                    written = Some(text.clone());
+                }
+                Ok(())
+            },
+        );
+
+        assert!(accepted);
+        assert_eq!(written.as_deref(), Some("中文测试 abc 123"));
+        assert_eq!(
+            clipboard_seen_text.lock().expect("seen lock").as_deref(),
+            Some("text:中文测试 abc 123")
+        );
+    }
+
+    #[test]
     fn clipboard_legacy_text_packet_is_still_accepted() {
         let layout = test_layout();
         let packet = ClipboardPacket {

--- a/src/desktopApi.ts
+++ b/src/desktopApi.ts
@@ -1,5 +1,4 @@
 import { invoke, isTauri } from '@tauri-apps/api/core'
-import type { Update } from '@tauri-apps/plugin-updater'
 import { RELEASES_URL, REPOSITORY_URL } from './constants'
 import { defaultLayout } from './defaultLayout'
 import type {
@@ -108,7 +107,6 @@ const FALLBACK_RUNTIME: RuntimeStatus = {
 }
 
 let browserRuntime = FALLBACK_RUNTIME
-let pendingAppUpdate: Update | null = null
 
 export async function loadAppState(): Promise<AppStateSnapshot> {
   if (!isTauri()) {
@@ -458,7 +456,6 @@ export async function checkForAppUpdate(): Promise<AppUpdateCheckResult> {
 
   const { check } = await import('@tauri-apps/plugin-updater')
   const update = await check()
-  pendingAppUpdate = update
 
   if (!update) {
     return { available: false }
@@ -489,7 +486,7 @@ export async function installAppUpdate(): Promise<void> {
     import('@tauri-apps/plugin-updater'),
     import('@tauri-apps/plugin-process'),
   ])
-  const update = pendingAppUpdate ?? (await check())
+  const update = await check()
 
   if (!update) {
     return
@@ -502,6 +499,5 @@ export async function installAppUpdate(): Promise<void> {
     await setAppUpgrading(false).catch(() => {})
     throw error
   }
-  pendingAppUpdate = null
   await relaunch()
 }


### PR DESCRIPTION
## Summary
- Fix Windows background input suspension when normal foreground windows cover the monitor.
- Keep discovery/QUIC alive when restarting input and clipboard runtime pieces.
- Refresh updater metadata and re-check latest installer before install.
- Add a regression test for non-ASCII clipboard text payloads.

## Verification
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo test --manifest-path src-tauri/Cargo.toml --lib -- --nocapture
- git diff --check
- npm run mac:build-install